### PR TITLE
Modified Events For listenOnSubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ In order to work, this method requires a browser that supports the HTML5 drag-an
 
 Like `instance.listenOnInput(input)`, except instead of listening for the "change" event on the input element, listen for the "click" event of a button.
 
+##### When the submitButton is clicked, the "submit" event is dispatched. Also, when the file input changes, the "choose" event will be dispatched.
 JavaScript:
 
 ```javascript
@@ -324,6 +325,14 @@ The events are documented below.
 #### choose
 
 The user has chosen files to upload, through any of the channels you have implemented.  If you want to cancel the upload, make your callback return `false`.
+
+##### Event Properties
+
+* `event.files` an instance of a W3C FileList object
+
+#### submit
+
+This event is triggered on instance.listenOnSubmit() when the user has clicked the submit button. 
 
 ##### Event Properties
 

--- a/client.js
+++ b/client.js
@@ -358,7 +358,27 @@
 			_load(files);
 		}
 	};
+	/* added by Josan
+	* use this function when submit button is clicked
+	*/
+    var _fileSubmitCallback = function(files) {
+      if (files.length === 0) return;
 
+      // Ensure existence of meta property on each file
+      for (var i = 0; i < files.length; i++) {
+        if (!files[i].meta) files[i].meta = {};
+      }
+
+      // Dispatch the "submit" event
+      var evntResult = _dispatch("submit", {
+        files: files
+      });
+
+      // If the callback didn't return false, continue with the upload
+      if (evntResult) {
+        _load(files);
+      }
+    };
 	/**
 	 * Private function that serves as a callback on file input.
 	 * @param  {Event} event The file input change event
@@ -406,8 +426,15 @@
 	this.listenOnSubmit = function (submitButton, input) {
 		if (!input.files) return;
 		_listenTo(submitButton, "click", function () {
-			_baseFileSelectCallback(input.files);
+			_fileSubmitCallback(input.files);
 		}, false);
+		/* added by Josan
+		* to trigger a choose event when the input element has been changed
+		*/
+      _listenTo(input, "change", function(e) {
+        //dispatch Event
+        _dispatch("choose", { files: input.files });
+      });
 	};
 
 	/**

--- a/list-of-names.md
+++ b/list-of-names.md
@@ -1,0 +1,1 @@
+iamjosan


### PR DESCRIPTION
While using this module in development, I found it confusing for the "choose" event to be dispatched when using `listenOnSubmit` and `listenOnInput`. It makes sense to dispatch the "choose" event after onChange for `listenOnInput` but not for `listenOnSubmit`.

Since `listenOnSubmit` listens for a "click" event, I thought it would make more sense to dispatch a "submit" event when the button is clicked. Not only does it coincide with the method name (`listenOnSubmit`), but it better represents the user action.

Aside from dispatching the "submit" event onClick, I allowed for the dispatch of the "choose" event for the file input onChange. 

Here is the flow works for `listenOnSubmit`: user selects file, "choose" event is dispatched. user clicks submit button, "submit" event is dispatched; "start" event is dispatched right after.

The main reason why I made these modifications is I needed to know when the user selected a file. Since I was using the `listenOnSubmit `method, it would only fire the "choose" event AFTER the submit button had been clicked, NOT when the file was selected.

Modifying the events to be dispatched in this manner allows for a better response to user actions.

